### PR TITLE
skip none values and not skip empty string for set_prop and check_prop

### DIFF
--- a/tests/common/test_ucscpropval.py
+++ b/tests/common/test_ucscpropval.py
@@ -12,38 +12,80 @@
 # limitations under the License.
 
 from nose.tools import *
+from ..connection.info import custom_setup, custom_teardown
 from ucscsdk.mometa.ls.LsServer import LsServer
-
-obj = None
-
-
-def setup_func():
-    global obj
-    obj = LsServer("org-root", "test")
+sp_test = None
+handle = None
 
 
-def teardown_func():
-    pass
+def setup():
+    global sp_test
+    global handle
+    handle = custom_setup()
+    org = handle.query_dn("org-root")
+
+    sp_test = LsServer(org, name="test", usr_lbl="TEST")
+    handle.add_mo(sp_test, True)
+    handle.commit()
 
 
-@with_setup(setup_func, teardown_func)
+def teardown():
+    handle.remove_mo(sp_test)
+    handle.commit()
+    custom_teardown(handle)
+
+
 @raises(Exception)
 def test_001_set_ro_property():
     # This is a read only property
     # Should fail with an exception
-    obj.oper_state = "up"
+    sp_test.oper_state = "up"
 
 
-@with_setup(setup_func, teardown_func)
 def test_002_set_rw_property():
     # This is a read write property.
     # Should happen without any issues
-    obj.descr = "test_description"
+    sp_test.descr = "test_description"
 
 
-@with_setup(setup_func(), teardown_func())
 @raises(Exception)
 def test_003_set_naming_property():
     # This is a naming property. so, it is create only
     # Should fail with an exception
-    obj.name = "test1"
+    sp_test.name = "test1"
+
+
+def test_004_set_prop_multiple():
+    # Setting multiple props of object
+    sp_test = handle.query_dn("org-root/ls-test")
+    sp_test.set_prop_multiple(usr_lbl= "NEW_LABEL",bios_profile_name="NEW_BIOS")
+    handle.add_mo(sp_test, modify_present=True)
+    handle.commit()
+    sp_test = handle.query_dn("org-root/ls-test")
+    assert_equal(sp_test.usr_lbl, "NEW_LABEL")
+    assert_equal(sp_test.bios_profile_name, "NEW_BIOS")
+
+
+def test_005_check_prop_match():
+    # Checking multiple props match for existing MO
+    sp_test = handle.query_dn("org-root/ls-test")
+    sp_test.set_prop_multiple(usr_lbl= "NEW_LABEL",bios_profile_name="NEW_BIOS")
+    handle.add_mo(sp_test, modify_present=True)
+    handle.commit()
+    args = {'usr_lbl' : "NEW_LABEL", 'bios_profile_name' : 'TEST_BIOS'}
+    exist = sp_test.check_prop_match(**args)
+    assert_equal(exist, False)
+    args = {'usr_lbl' : "NEW_LABEL", 'bios_profile_name' : 'NEW_BIOS'}
+    exist = sp_test.check_prop_match(**args)
+    assert_equal(exist, True)
+
+
+def test_006_clear_prop():
+    # Clearing props for existing MO
+    sp_test = handle.query_dn("org-root/ls-test")
+    sp_test.set_prop_multiple(usr_lbl= "",bios_profile_name="")
+    handle.add_mo(sp_test, modify_present=True)
+    handle.commit()
+    sp_test = handle.query_dn("org-root/ls-test")
+    assert_equal(sp_test.usr_lbl, "")
+    assert_equal(sp_test.bios_profile_name, "")

--- a/ucscsdk/ucscmo.py
+++ b/ucscsdk/ucscmo.py
@@ -177,7 +177,7 @@ class ManagedObject(UcscBase):
                         prop_meta.access != \
                         ucsccoremeta.MoPropertyMeta.CREATE_ONLY:
                     raise ValueError("%s is not a read-write property." % name)
-            if not prop_meta.validate_property_value(value):
+            if value and not prop_meta.validate_property_value(value):
                 raise ValueError("Invalid Value Exception - "
                                  "[%s]: Prop <%s>, Value<%s>. "
                                  % (self.__class__.__name__,
@@ -198,7 +198,8 @@ class ManagedObject(UcscBase):
                                  "Class [%s]: Prop <%s> "
                                  % (self.__class__.__name__, prop_name))
 
-            if kwargs[prop_name] != self.__get_prop(prop_name):
+            if kwargs[prop_name] is not None and \
+                    kwargs[prop_name] != self.__get_prop(prop_name):
                 return False
         return True
 


### PR DESCRIPTION
skip none values from and not skip empty string
for set_prop_match, check_prop_match to be consistent with set_attr. 
So empty string is allowed and it helps in clearing the value, while None is skipped all the time.
to_xml already skips the None values.

Signed-off-by: Parag Shah <parag.may4@gmail.com>