### PR TITLE
Fix typo of ucscsdk.ucsccoreutils in the documentation

### DIFF
--- a/docs/ucscsdk_ug.rst
+++ b/docs/ucscsdk_ug.rst
@@ -522,7 +522,7 @@ object.
 
 ::
 
-    from ucscsdk.ucscoreutils import get_meta_info
+    from ucscsdk.ucsccoreutils import get_meta_info
 
     class_meta = get_meta_info("FabricVlan")
     print class_meta


### PR DESCRIPTION
There is a typo in the documentation:
```
>>> from ucscsdk.ucscoreutils import get_meta_info
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named ucscoreutils
No module named ucscoreutils
```