### PR TITLE
cast refresh_period to integer

### DIFF
--- a/ucscsdk/ucscsession.py
+++ b/ucscsdk/ucscsession.py
@@ -160,7 +160,7 @@ class UcscSession(object):
         self.__cookie = response.out_cookie
         self.__session_id = response.out_session_id
         self.__version = UcscVersion(response.out_version)
-        self.__refresh_period = response.out_refresh_period
+        self.__refresh_period = int(response.out_refresh_period)
         self.__priv = response.out_priv
         self.__domains = response.out_domains
         self.__channel = response.out_channel


### PR DESCRIPTION
In Python3 environment we are facing following error:
```
s._refresh(auto_relogin=True)
True
s._UcscSession__start_refresh_timer()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/Users/d069844/pythons/3.8/lib/python3.8/site-packages/ucscsdk/ucscsession.py", line 365, in __start_refresh_timer
    if self.__refresh_period > 60:
TypeError: '>' not supported between instances of 'str' and 'int'

```