### PR TITLE
Allow TLS version other than v1

### DIFF
--- a/ucscsdk/ucscdriver.py
+++ b/ucscsdk/ucscdriver.py
@@ -68,7 +68,7 @@ class TLS1Connection(httplib.HTTPSConnection):
 
         # This is the only difference; default wrap_socket uses SSLv23
         self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-                                    ssl_version=ssl.PROTOCOL_TLSv1)
+                                    ssl_version=ssl.PROTOCOL_TLS)
 
 
 class UcscDriver(object):


### PR DESCRIPTION
ssl.PROTOCOL_TLS allows the highest version of TLS supported between client and server. UCS Central has deprecated TLSv1.