### PR TITLE
fix: getchildren() removed in python 3.9

### DIFF
--- a/ucscsdk/ucsccore.py
+++ b/ucscsdk/ucsccore.py
@@ -192,7 +192,7 @@ class BaseObject(UcscBase):
                     ucscgenutils.convert_to_python_var_name(attr_name),
                     str(attr_value))
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not ET.iselement(child_elem):

--- a/ucscsdk/ucscmethod.py
+++ b/ucscsdk/ucscmethod.py
@@ -140,7 +140,7 @@ class ExternalMethod(UcscBase):
                         ExternalMethod._external_method_attrs[attr_name],
                         str(attr_value))
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not ET.iselement(child_elem):

--- a/ucscsdk/ucscmo.py
+++ b/ucscsdk/ucscmo.py
@@ -378,7 +378,7 @@ class ManagedObject(UcscBase):
             self.__set_prop("rn", os.path.basename(self.dn), forced=True)
         self.mark_clean()
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not ET.iselement(child_elem):
@@ -597,7 +597,7 @@ class GenericMo(UcscBase):
         # else:
         #     raise ValueError("Both rn and dn does not present.")
 
-        children = elem.getchildren()
+        children = list(elem)
         if children:
             for child in children:
                 if not ET.iselement(child):


### PR DESCRIPTION
xml.etree.ElementTree.Element deprecated .getchildren() in python 3.2
and it was removed in 3.9 (see https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren)

Swapping from elem.getchildren() to list(elem) for compatibility.

Fixes #45 