### PR TITLE
Support for TLSv1, v1.1, v1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     package_dir={'ucscsdk':
                  'ucscsdk'},
     include_package_data=True,
-    install_requires=['pyparsing'],
+    install_requires=['pyparsing', 'six'],
     license="http://www.apache.org/licenses/LICENSE-2.0",
     zip_safe=False,
     keywords='ucscsdk',


### PR DESCRIPTION
- Support for TLSv1, v1.1, v1.2
- Implemented the TLSv1 fallback logic when TLSv1.1/1.2 fail
- Using six.moves.urllib instead of urllib2
- Implemented the TLS connection similar to Ucsm SDK